### PR TITLE
refactor!: adopt huma-observability v2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ Huma Playground is a minimal REST API skeleton built with [Huma](https://github.
 
 ### Key Features
 
-- Chi middleware stack with untrusted forwarding-header removal, security headers, environment-aware CORS, direct-peer IP recording, request size limits, and panic recovery
-- Huma observability middleware via `github.com/janisto/huma-observability` for router-wide request IDs, Huma access logs, request-scoped Zap loggers, and trace metadata enrichment
+- Chi middleware stack with untrusted forwarding-header removal, security headers, environment-aware CORS, privacy-minimized access logging, request size limits, and panic recovery
+- Huma observability middleware via `github.com/janisto/huma-observability/v2` for router-wide request IDs, Huma access logs, request-scoped Zap loggers, and trace metadata enrichment
 - Plain response bodies with RFC 9457 Problem Details for errors
 - Content negotiation supporting JSON and CBOR formats
 - Cursor-based pagination with RFC 8288 Link headers
@@ -325,17 +325,17 @@ Panic recovery and Chi-level handlers use Problem Details via `internal/platform
 
 ### Logging
 
-Use request-scoped loggers from `github.com/janisto/huma-observability`:
+Use request-scoped loggers from `github.com/janisto/huma-observability/v2`:
 
 ```go
-import "github.com/janisto/huma-observability"
+import "github.com/janisto/huma-observability/v2"
 
 obs.Logger(ctx).Info("message", zap.String("key", "value"))
 obs.Logger(ctx).Warn("message", zap.String("key", "value"))
 obs.Logger(ctx).Error("message", zap.Error(err), zap.String("key", "value"))
 ```
 
-`obs.Logger(ctx)` preserves request metadata installed by router-wide `obs.HTTPRequestContext` and Huma `obs.RequestContext`. It intentionally returns a no-op logger when no request logger is installed. That means audit helpers and service warning logs are valid only for request-driven paths; direct service calls, background jobs, scripts, and tests using `context.Background()` must use an explicit process logger instead. `obs.AccessLogger` emits Huma operation-aware access logs. Use `internal/platform/middleware.AccessLogger` only for Chi-only route groups and Chi error handlers to avoid duplicate `/v1` access logs. Use the startup logger returned by `obs.NewLogger` for process-level logs outside a request context.
+`obs.Logger(ctx)` preserves request metadata installed by router-wide `obs.HTTPRequestContext` and Huma `obs.RequestContext`. It intentionally returns a no-op logger when no request logger is installed. That means audit helpers and service warning logs are valid only for request-driven paths; direct service calls, background jobs, scripts, and tests using `context.Background()` must use an explicit process logger instead. The app pins Trace Context Level 1 across both context middleware layers and `obs.AccessLogger`. Huma and Chi access logs omit raw paths, peer IPs, and user agents; use route templates for aggregation. Use `internal/platform/middleware.AccessLogger` only for Chi-only route groups and Chi error handlers to avoid duplicate `/v1` access logs. Use the startup logger returned by `obs.NewLogger` for process-level logs outside a request context.
 
 At HTTP dependency boundaries, log unavailable/time-out failures at warning level and unexpected failures at error level exactly once, including a stable operation name and the underlying error. Keep expected domain outcomes such as not found or already exists out of duplicate error logs. Never return dependency internals to clients or log tokens, request bodies, profile data, or other PII.
 

--- a/README.md
+++ b/README.md
@@ -251,11 +251,11 @@ detailed [format specification](https://agentskills.io/specification), under `.a
 
 ## Observability
 
-`obs.HTTPRequestContext` is installed at the Chi boundary so liveness, recovery, 404, 405, and Huma routes share request IDs and trace metadata. Huma routes additionally use `obs.RequestContext` and `obs.AccessLogger` for operation-aware logs.
+The app uses `github.com/janisto/huma-observability/v2`. `obs.HTTPRequestContext` is installed at the Chi boundary so liveness, recovery, 404, 405, and Huma routes share request IDs, request-scoped loggers, and W3C trace metadata. The HTTP and Huma middleware explicitly use Trace Context Level 1. Huma routes additionally use `obs.RequestContext` and `obs.AccessLogger` for operation-aware logs.
 
-The local Chi access logger wraps only Chi-only routes and error handlers, preventing duplicate `/v1` access logs. `obs.Logger(ctx)` is intentionally request-bound; process and background work must receive an explicit logger.
+Access logs are privacy-minimized: Huma records route templates and operation IDs without raw paths, peer IPs, or user agents; the local Chi logger follows the same boundary and wraps only Chi-only routes and error handlers. Escaping non-abort panic records use `terminal_reason: "panic"` and error severity without inventing an unobserved status. This split also prevents duplicate `/v1` access logs. `obs.Logger(ctx)` is intentionally request-bound; process and background work must receive an explicit logger.
 
-The recorded client address is the direct network peer. Forwarding headers are removed at the outer HTTP boundary because this example does not define a trusted-proxy boundary; this also prevents forwarded-host values from influencing Huma schema links.
+Forwarding headers are removed at the outer HTTP boundary because this example does not define a trusted-proxy boundary; this also prevents forwarded-host values from influencing Huma schema links.
 
 ## Security notes
 

--- a/cmd/server/application.go
+++ b/cmd/server/application.go
@@ -12,7 +12,7 @@ import (
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 
 	"github.com/janisto/huma-playground/internal/http/health"
@@ -30,6 +30,8 @@ type dependencies struct {
 	profiles profilesvc.Store
 	github   githubsvc.Service
 }
+
+const observabilityTraceContextLevel = obs.TraceContextLevel1
 
 type applicationClients struct {
 	*firebase.Clients
@@ -120,8 +122,16 @@ func newRouter(cfg config, deps dependencies, logger *zap.Logger) http.Handler {
 
 	apiRouter := chi.NewRouter()
 	api := humachi.New(apiRouter, apiConfig)
-	api.UseMiddleware(obs.RequestContext(obs.RequestContextConfig{Logger: logger, Preset: obs.PresetGCP}))
-	api.UseMiddleware(obs.AccessLogger(obs.AccessLoggerConfig{Logger: logger, Preset: obs.PresetGCP}))
+	api.UseMiddleware(obs.RequestContext(obs.RequestContextConfig{
+		Logger:            logger,
+		Preset:            obs.PresetGCP,
+		TraceContextLevel: observabilityTraceContextLevel,
+	}))
+	api.UseMiddleware(obs.AccessLogger(obs.AccessLoggerConfig{
+		Logger:            logger,
+		Preset:            obs.PresetGCP,
+		TraceContextLevel: observabilityTraceContextLevel,
+	}))
 	addCBOROpenAPIContent(api)
 	auth.RegisterSecurityScheme(api)
 	routes.Register(api, cfg.APIPrefix, deps.verifier, deps.profiles, deps.github)
@@ -134,7 +144,11 @@ func newRouter(cfg config, deps dependencies, logger *zap.Logger) http.Handler {
 	router.MethodNotAllowed(httpAccessLogger(respond.MethodNotAllowedHandler(api)).ServeHTTP)
 	router.Use(
 		appmiddleware.IgnoreForwardedHeaders(),
-		obs.HTTPRequestContext(obs.HTTPRequestContextConfig{Logger: logger, Preset: obs.PresetGCP}),
+		obs.HTTPRequestContext(obs.HTTPRequestContextConfig{
+			Logger:            logger,
+			Preset:            obs.PresetGCP,
+			TraceContextLevel: observabilityTraceContextLevel,
+		}),
 		respond.Recoverer(api, logger),
 		requestContextTimeout(cfg.RequestTimeout),
 		appmiddleware.Security(cfg.APIPrefix),

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 
 	_ "github.com/danielgtaylor/huma/v2/formats/cbor"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	_ "github.com/joho/godotenv/autoload"
 	"go.uber.org/zap"
 )

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 
 	"github.com/janisto/huma-playground/internal/http/health"
@@ -46,6 +48,11 @@ func testConfig(t *testing.T) config {
 
 func testRouter(t *testing.T, cfg config) http.Handler {
 	t.Helper()
+	return testRouterWithLogger(t, cfg, zap.NewNop())
+}
+
+func testRouterWithLogger(t *testing.T, cfg config, logger *zap.Logger) http.Handler {
+	t.Helper()
 	githubClient, err := githubsvc.NewClient(http.DefaultClient)
 	if err != nil {
 		t.Fatalf("create GitHub client: %v", err)
@@ -54,7 +61,7 @@ func testRouter(t *testing.T, cfg config) http.Handler {
 		verifier: &stubVerifier{User: testUser()},
 		profiles: unavailableProfileStore{},
 		github:   githubClient,
-	}, zap.NewNop())
+	}, logger)
 }
 
 func TestLoadConfigDefaults(t *testing.T) {
@@ -272,6 +279,113 @@ func TestRouterHealthAndRequestID(t *testing.T) {
 	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode health: %v", err)
 	}
+}
+
+func TestRouterHumaAccessLogUsesV2PrivacyContract(t *testing.T) {
+	logger, output := testObservabilityLogger(t)
+	router := testRouterWithLogger(t, testConfig(t), logger)
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/hello", nil)
+	request.Header.Set(middleware.RequestIDHeader, "observability-request")
+	request.Header.Set("Traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-03")
+	request.Header.Set("User-Agent", "private-test-agent")
+	request.RemoteAddr = "203.0.113.10:12345"
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", response.Code, response.Body.String())
+	}
+	if got := response.Header().Get(middleware.RequestIDHeader); got != "observability-request" {
+		t.Fatalf("response request ID = %q, want observability-request", got)
+	}
+	records := decodeLogRecords(t, output.Bytes())
+	application := singleLogRecord(t, records, "hello get")
+	access := singleLogRecord(t, records, "request completed")
+	if got := countLogRecords(records, "http request completed"); got != 0 {
+		t.Fatalf("Huma request emitted %d Chi access logs", got)
+	}
+	for name, record := range map[string]map[string]any{"application": application, "access": access} {
+		assertJSONLogField(t, record, "request_id", "observability-request")
+		assertJSONLogField(t, record, "correlation_id", "4bf92f3577b34da6a3ce929d0e0e4736")
+		assertJSONLogField(t, record, "trace_sampled", true)
+		if _, ok := record["trace_id_random"]; ok {
+			t.Fatalf("%s record unexpectedly used Trace Context Level 2: %#v", name, record)
+		}
+	}
+	assertJSONLogField(t, access, "severity", "INFO")
+	assertJSONLogField(t, access, "method", http.MethodGet)
+	assertJSONLogField(t, access, "path_template", "/hello")
+	assertJSONLogField(t, access, "operation_id", "get-hello")
+	assertJSONLogField(t, access, "status", float64(http.StatusOK))
+	assertNoJSONLogFields(t, access, "path", "peer_ip", "remote_ip", "user_agent")
+	httpRequest, ok := access["httpRequest"].(map[string]any)
+	if !ok {
+		t.Fatalf("httpRequest = %#v, want object", access["httpRequest"])
+	}
+	assertJSONLogField(t, httpRequest, "requestMethod", http.MethodGet)
+	assertJSONLogField(t, httpRequest, "status", float64(http.StatusOK))
+	assertNoJSONLogFields(t, httpRequest, "requestUrl", "remoteIp", "userAgent")
+}
+
+func TestRouterHumaAccessLogPreservesErrorStatus(t *testing.T) {
+	logger, output := testObservabilityLogger(t)
+	router := testRouterWithLogger(t, testConfig(t), logger)
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/profile", nil)
+	request.Header.Set(middleware.RequestIDHeader, "auth-observability-request")
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 Unauthorized, got %d: %s", response.Code, response.Body.String())
+	}
+	records := decodeLogRecords(t, output.Bytes())
+	access := singleLogRecord(t, records, "request completed")
+	if got := countLogRecords(records, "http request completed"); got != 0 {
+		t.Fatalf("Huma request emitted %d Chi access logs", got)
+	}
+	assertJSONLogField(t, access, "severity", "WARNING")
+	assertJSONLogField(t, access, "request_id", "auth-observability-request")
+	assertJSONLogField(t, access, "method", http.MethodGet)
+	assertJSONLogField(t, access, "path_template", "/profile")
+	assertJSONLogField(t, access, "operation_id", "get-profile")
+	assertJSONLogField(t, access, "status", float64(http.StatusUnauthorized))
+	assertNoJSONLogFields(t, access, "terminal_reason")
+	httpRequest, ok := access["httpRequest"].(map[string]any)
+	if !ok {
+		t.Fatalf("httpRequest = %#v, want object", access["httpRequest"])
+	}
+	assertJSONLogField(t, httpRequest, "requestMethod", http.MethodGet)
+	assertJSONLogField(t, httpRequest, "status", float64(http.StatusUnauthorized))
+}
+
+func TestRouterChiAccessLogUsesV2PrivacyContract(t *testing.T) {
+	logger, output := testObservabilityLogger(t)
+	router := testRouterWithLogger(t, testConfig(t), logger)
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+	request.Header.Set(middleware.RequestIDHeader, "health-observability-request")
+	request.Header.Set("User-Agent", "private-test-agent")
+	request.RemoteAddr = "203.0.113.10:12345"
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", response.Code, response.Body.String())
+	}
+	records := decodeLogRecords(t, output.Bytes())
+	access := singleLogRecord(t, records, "http request completed")
+	if got := countLogRecords(records, "request completed"); got != 0 {
+		t.Fatalf("Chi request emitted %d Huma access logs", got)
+	}
+	assertJSONLogField(t, access, "request_id", "health-observability-request")
+	assertJSONLogField(t, access, "correlation_id", "health-observability-request")
+	assertJSONLogField(t, access, "severity", "INFO")
+	assertJSONLogField(t, access, "method", http.MethodGet)
+	assertJSONLogField(t, access, "path_template", "/health")
+	assertJSONLogField(t, access, "status", float64(http.StatusOK))
+	assertNoJSONLogFields(t, access, "path", "peer_ip", "remote_ip", "user_agent", "httpRequest")
 }
 
 func TestRouterDoesNotTrustForwardedHostForSchemaLinks(t *testing.T) {
@@ -571,5 +685,80 @@ func TestOpenAPIResponseStatusesAndSecurityMatchRuntime(t *testing.T) {
 func TestVersionDefault(t *testing.T) {
 	if Version != "dev" {
 		t.Fatalf("unexpected default version %q", Version)
+	}
+}
+
+func testObservabilityLogger(t *testing.T) (*zap.Logger, *bytes.Buffer) {
+	t.Helper()
+	output := &bytes.Buffer{}
+	logger, err := obs.NewLogger(obs.LoggerConfig{
+		Preset:      obs.PresetGCP,
+		Writer:      output,
+		ErrorWriter: output,
+	})
+	if err != nil {
+		t.Fatalf("create observability logger: %v", err)
+	}
+	return logger, output
+}
+
+func decodeLogRecords(t *testing.T, output []byte) []map[string]any {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(output), []byte{'\n'})
+	records := make([]map[string]any, 0, len(lines))
+	for index, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal(line, &record); err != nil {
+			t.Fatalf("decode log record %d: %v; line=%q", index, err, line)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func singleLogRecord(t *testing.T, records []map[string]any, message string) map[string]any {
+	t.Helper()
+	var match map[string]any
+	for _, record := range records {
+		if record["message"] != message {
+			continue
+		}
+		if match != nil {
+			t.Fatalf("multiple log records with message %q: %#v", message, records)
+		}
+		match = record
+	}
+	if match == nil {
+		t.Fatalf("no log record with message %q: %#v", message, records)
+	}
+	return match
+}
+
+func countLogRecords(records []map[string]any, message string) int {
+	count := 0
+	for _, record := range records {
+		if record["message"] == message {
+			count++
+		}
+	}
+	return count
+}
+
+func assertJSONLogField(t *testing.T, record map[string]any, key string, want any) {
+	t.Helper()
+	if got := record[key]; got != want {
+		t.Fatalf("log field %q = %#v, want %#v; record=%#v", key, got, want, record)
+	}
+}
+
+func assertNoJSONLogFields(t *testing.T, record map[string]any, keys ...string) {
+	t.Helper()
+	for _, key := range keys {
+		if _, ok := record[key]; ok {
+			t.Fatalf("log record unexpectedly contains %q: %#v", key, record)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.2
-	github.com/janisto/huma-observability v0.3.0
+	github.com/janisto/huma-observability/v2 v2.0.0
 	github.com/joho/godotenv v1.5.1
 	go.uber.org/zap v1.28.0
 	google.golang.org/grpc v1.82.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.18 h1:hvVi34VucdrV1IIsiW
 github.com/googleapis/enterprise-certificate-proxy v0.3.18/go.mod h1:rSEsBUemEBZEexP2y6jPp16LUmUbjmSbcPMQizR0o4k=
 github.com/googleapis/gax-go/v2 v2.23.0 h1:Tchl7qkvE7Ip3y+ztvNufYFvkfqTe7NfLTYGIdJRLuE=
 github.com/googleapis/gax-go/v2 v2.23.0/go.mod h1:rBQKOVJCdb8IFEzg+FCwlt1LP/xMDGuqUXhUG+XMXEg=
-github.com/janisto/huma-observability v0.3.0 h1:pN5bJVXYt+sjoy4fOijpjQRq8YGRmUWGqW1PJQB5xqo=
-github.com/janisto/huma-observability v0.3.0/go.mod h1:+QFk6SIjeI84WzggvqRnIh2MK84jXLCQIYka2o0hGPc=
+github.com/janisto/huma-observability/v2 v2.0.0 h1:9+Do26x+eIVfGCaEjArqcz9w6UnJ6RZqZXJ7Z3c7ze8=
+github.com/janisto/huma-observability/v2 v2.0.0/go.mod h1:JHDreE48ti8IeQrLIGiOdMclVIzXy162R3tiYLoNRho=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/internal/http/v1/github/handler.go
+++ b/internal/http/v1/github/handler.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 
 	"github.com/danielgtaylor/huma/v2"
-	obs "github.com/janisto/huma-observability"
+	obs "github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 
 	"github.com/janisto/huma-playground/internal/platform/pagination"

--- a/internal/http/v1/github/handler_test.go
+++ b/internal/http/v1/github/handler_test.go
@@ -14,7 +14,7 @@ import (
 	humachi "github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 

--- a/internal/http/v1/hello/handler.go
+++ b/internal/http/v1/hello/handler.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 )
 

--- a/internal/http/v1/hello/handler_test.go
+++ b/internal/http/v1/hello/handler_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 )
 
 func newTestRouter() chi.Router {

--- a/internal/http/v1/items/handler_test.go
+++ b/internal/http/v1/items/handler_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 
 	"github.com/janisto/huma-playground/internal/platform/pagination"
 )

--- a/internal/http/v1/profile/handler.go
+++ b/internal/http/v1/profile/handler.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
-	obs "github.com/janisto/huma-observability"
+	obs "github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 
 	"github.com/janisto/huma-playground/internal/platform/auth"

--- a/internal/http/v1/profile/handler_test.go
+++ b/internal/http/v1/profile/handler_test.go
@@ -15,7 +15,7 @@ import (
 	humachi "github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 

--- a/internal/http/v1/routes/routes_test.go
+++ b/internal/http/v1/routes/routes_test.go
@@ -13,7 +13,7 @@ import (
 	_ "github.com/danielgtaylor/huma/v2/formats/cbor"
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 
 	"github.com/janisto/huma-playground/internal/platform/auth"
 	githubsvc "github.com/janisto/huma-playground/internal/service/github"

--- a/internal/platform/audit/audit.go
+++ b/internal/platform/audit/audit.go
@@ -3,7 +3,7 @@ package audit
 import (
 	"context"
 
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 )
 

--- a/internal/platform/audit/audit_test.go
+++ b/internal/platform/audit/audit_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"

--- a/internal/platform/auth/middleware.go
+++ b/internal/platform/auth/middleware.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 )
 

--- a/internal/platform/middleware/accesslog.go
+++ b/internal/platform/middleware/accesslog.go
@@ -2,13 +2,14 @@ package middleware
 
 import (
 	"errors"
-	"net"
 	"net/http"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // AccessLogger writes structured access logs for non-Huma HTTP handlers.
@@ -29,7 +30,7 @@ func logHTTPAccess(r *http.Request, ww chimiddleware.WrapResponseWriter, start t
 		if err, ok := rec.(error); ok && errors.Is(err, http.ErrAbortHandler) {
 			panic(rec)
 		}
-		logHTTPRequest(r, ww, start, http.StatusInternalServerError)
+		logHTTPRequest(r, ww, start, ww.Status(), "panic")
 		panic(rec)
 	}
 
@@ -37,33 +38,36 @@ func logHTTPAccess(r *http.Request, ww chimiddleware.WrapResponseWriter, start t
 	if status == 0 {
 		status = http.StatusOK
 	}
-	logHTTPRequest(r, ww, start, status)
+	logHTTPRequest(r, ww, start, status, "")
 }
 
-func logHTTPRequest(r *http.Request, ww chimiddleware.WrapResponseWriter, start time.Time, status int) {
+func logHTTPRequest(
+	r *http.Request,
+	ww chimiddleware.WrapResponseWriter,
+	start time.Time,
+	status int,
+	terminalReason string,
+) {
 	fields := []zap.Field{
 		zap.String("method", r.Method),
-		zap.String("path", r.URL.EscapedPath()),
-		zap.Int("status", status),
 		zap.Int("bytes_written", ww.BytesWritten()),
 		zap.Float64("duration_ms", float64(time.Since(start))/float64(time.Millisecond)),
 	}
-	if remoteIP := requestRemoteIP(r.RemoteAddr); remoteIP != "" {
-		fields = append(fields, zap.String("remote_ip", remoteIP))
+	if routeContext := chi.RouteContext(r.Context()); routeContext != nil {
+		if pathTemplate := routeContext.RoutePattern(); pathTemplate != "" {
+			fields = append(fields, zap.String("path_template", pathTemplate))
+		}
 	}
-	if userAgent := r.UserAgent(); userAgent != "" {
-		fields = append(fields, zap.String("user_agent", userAgent))
+	if status != 0 {
+		fields = append(fields, zap.Int("status", status))
+	}
+	level := zapcore.InfoLevel
+	if terminalReason != "" {
+		fields = append(fields, zap.String("terminal_reason", terminalReason))
+		level = zapcore.ErrorLevel
+	} else if status != 0 {
+		level = obs.DefaultStatusLevel(status)
 	}
 
-	obs.Logger(r.Context()).Info("http request completed", fields...)
-}
-
-func requestRemoteIP(remoteAddr string) string {
-	if remoteAddr == "" {
-		return ""
-	}
-	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
-		return host
-	}
-	return remoteAddr
+	obs.Logger(r.Context()).Log(level, "http request completed", fields...)
 }

--- a/internal/platform/middleware/accesslog_test.go
+++ b/internal/platform/middleware/accesslog_test.go
@@ -6,8 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -16,11 +17,14 @@ import (
 func TestAccessLoggerLogsHTTPRequest(t *testing.T) {
 	core, recorded := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core)
+	router := chi.NewRouter()
+	router.Use(AccessLogger())
+	router.Get("/ready", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("tea"))
+	})
 	handler := obs.HTTPRequestContext(obs.HTTPRequestContextConfig{Logger: logger})(
-		AccessLogger()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusTeapot)
-			_, _ = w.Write([]byte("tea"))
-		})),
+		router,
 	)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ready", nil)
@@ -41,17 +45,19 @@ func TestAccessLoggerLogsHTTPRequest(t *testing.T) {
 	fields := entries[0].ContextMap()
 	assertLogField(t, fields, "request_id", "access-req")
 	assertLogField(t, fields, "method", http.MethodGet)
-	assertLogField(t, fields, "path", "/ready")
+	assertLogField(t, fields, "path_template", "/ready")
 	assertLogField(t, fields, "status", int64(http.StatusTeapot))
 	assertLogField(t, fields, "bytes_written", int64(3))
-	assertLogField(t, fields, "remote_ip", "203.0.113.10")
-	assertLogField(t, fields, "user_agent", "test-agent")
+	assertNoLogFields(t, fields, "path", "peer_ip", "remote_ip", "user_agent")
 	if _, ok := fields["duration_ms"]; !ok {
 		t.Fatalf("expected duration_ms field, got %#v", fields)
 	}
+	if entries[0].Level != zapcore.WarnLevel {
+		t.Fatalf("expected warning access log, got %s", entries[0].Level)
+	}
 }
 
-func TestAccessLoggerLogsPanicStatusAndRepanics(t *testing.T) {
+func TestAccessLoggerLogsPanicTerminalReasonAndRepanics(t *testing.T) {
 	core, recorded := observer.New(zapcore.InfoLevel)
 	logger := zap.New(core)
 	handler := obs.HTTPRequestContext(obs.HTTPRequestContextConfig{Logger: logger})(
@@ -64,8 +70,8 @@ func TestAccessLoggerLogsPanicStatusAndRepanics(t *testing.T) {
 	resp := httptest.NewRecorder()
 
 	defer func() {
-		if rec := recover(); rec == nil {
-			t.Fatal("expected panic")
+		if rec := recover(); rec != "boom" {
+			t.Fatalf("panic = %#v, want %q", rec, "boom")
 		}
 		entries := recorded.FilterMessage("http request completed").All()
 		if len(entries) != 1 {
@@ -73,7 +79,43 @@ func TestAccessLoggerLogsPanicStatusAndRepanics(t *testing.T) {
 		}
 		fields := entries[0].ContextMap()
 		assertLogField(t, fields, "request_id", "panic-req")
-		assertLogField(t, fields, "status", int64(http.StatusInternalServerError))
+		assertLogField(t, fields, "terminal_reason", "panic")
+		assertNoLogFields(t, fields, "status")
+		if entries[0].Level != zapcore.ErrorLevel {
+			t.Fatalf("expected error access log, got %s", entries[0].Level)
+		}
+	}()
+
+	handler.ServeHTTP(resp, req)
+}
+
+func TestAccessLoggerPanicRetainsCommittedStatus(t *testing.T) {
+	core, recorded := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+	handler := obs.HTTPRequestContext(obs.HTTPRequestContextConfig{Logger: logger})(
+		AccessLogger()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			panic("boom")
+		})),
+	)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/panic", nil)
+	req.Header.Set(chimiddleware.RequestIDHeader, "partial-panic-req")
+	resp := httptest.NewRecorder()
+
+	defer func() {
+		if rec := recover(); rec != "boom" {
+			t.Fatalf("panic = %#v, want %q", rec, "boom")
+		}
+		entries := recorded.FilterMessage("http request completed").All()
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 access log, got %d", len(entries))
+		}
+		fields := entries[0].ContextMap()
+		assertLogField(t, fields, "status", int64(http.StatusAccepted))
+		assertLogField(t, fields, "terminal_reason", "panic")
+		if entries[0].Level != zapcore.ErrorLevel {
+			t.Fatalf("expected error access log, got %s", entries[0].Level)
+		}
 	}()
 
 	handler.ServeHTTP(resp, req)
@@ -100,8 +142,9 @@ func TestAccessLoggerLogsImplicitOK(t *testing.T) {
 	assertLogField(t, fields, "request_id", "ok-req")
 	assertLogField(t, fields, "status", int64(http.StatusOK))
 	assertLogField(t, fields, "bytes_written", int64(0))
-	if _, ok := fields["remote_ip"]; ok {
-		t.Fatalf("did not expect remote_ip field in %#v", fields)
+	assertNoLogFields(t, fields, "path", "peer_ip", "remote_ip", "user_agent", "terminal_reason")
+	if entries[0].Level != zapcore.InfoLevel {
+		t.Fatalf("expected info access log, got %s", entries[0].Level)
 	}
 }
 
@@ -135,30 +178,18 @@ func TestAccessLoggerRepanicsAbortHandlerWithoutLogging(t *testing.T) {
 	handler.ServeHTTP(resp, req)
 }
 
-func TestRequestRemoteIP(t *testing.T) {
-	tests := map[string]struct {
-		remoteAddr string
-		want       string
-	}{
-		"empty":          {"", ""},
-		"host port":      {"203.0.113.10:12345", "203.0.113.10"},
-		"host only":      {"203.0.113.10", "203.0.113.10"},
-		"ipv6 host port": {"[2001:db8::1]:443", "2001:db8::1"},
-		"ipv6 host only": {"2001:db8::1", "2001:db8::1"},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			if got := requestRemoteIP(tt.remoteAddr); got != tt.want {
-				t.Fatalf("expected %q, got %q", tt.want, got)
-			}
-		})
-	}
-}
-
 func assertLogField(t *testing.T, fields map[string]any, key string, want any) {
 	t.Helper()
 	if got := fields[key]; got != want {
 		t.Fatalf("expected log field %s=%v, got %v in %#v", key, want, got, fields)
+	}
+}
+
+func assertNoLogFields(t *testing.T, fields map[string]any, keys ...string) {
+	t.Helper()
+	for _, key := range keys {
+		if _, ok := fields[key]; ok {
+			t.Fatalf("did not expect log field %q in %#v", key, fields)
+		}
 	}
 }

--- a/internal/platform/respond/respond.go
+++ b/internal/platform/respond/respond.go
@@ -11,7 +11,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/go-chi/chi/v5"
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 
 	appmiddleware "github.com/janisto/huma-playground/internal/platform/middleware"

--- a/internal/service/github/client.go
+++ b/internal/service/github/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/janisto/huma-observability"
+	"github.com/janisto/huma-observability/v2"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
## Why

huma-observability v2 is an intentional breaking release. The app needed to adopt its explicit trace-context and access-log contracts instead of carrying v1 assumptions forward.

## What changed

- upgrade the dependency and imports to `github.com/janisto/huma-observability/v2`
- pin Trace Context Level 1 across the HTTP and Huma middleware
- align Chi-only access logs with v2 privacy, severity, route-template, and panic semantics
- add composed-router coverage for successful and unauthorized Huma access logs
- strengthen panic tests to prove the original panic value escapes
- document the new observability contract and migration impact

## Impact

This deliberately changes the access-log contract:

- raw paths, peer IPs, and user agents are no longer emitted
- escaping non-abort panics use `terminal_reason: "panic"` and do not synthesize status 500
- no v1 compatibility shim is retained

## Validation

- `just test-app -run TestRouterHumaAccessLogPreservesErrorStatus -count=1`
- `just test-app -run TestAccessLogger -count=1`
- `just qa`
- `git diff --check`

## Remaining risk

The middleware affects every request, but regression coverage exercises both Huma and Chi ownership, success and error severity, trace metadata, privacy exclusions, and panic propagation. Firebase emulator integration was not rerun because Firebase behavior is unchanged.